### PR TITLE
Add directory-specific default view mode

### DIFF
--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -1040,6 +1040,54 @@ static bool showTocByDefault(const char* path) {
     return showByDefault;
 }
 
+static DisplayMode GetDirDefaultDisplayMode(const char* filePath) {
+    TempStr dir = path::GetDirTemp(filePath);
+    while (dir) {
+        TempStr cfg = path::JoinTemp(dir, "_pdfsettings.txt");
+        if (file::Exists(cfg)) {
+            ByteSlice data = file::ReadFile(cfg);
+            char* txt = (char*)data.data();
+            if (txt) {
+                if (str::StartsWith(txt, UTF8_BOM)) {
+                    txt += 3;
+                }
+                for (char* line = txt; *line;) {
+                    char* next = str::FindChar(line, '\n');
+                    if (next) {
+                        *next = 0;
+                    }
+                    str::TrimWSInPlace(line, TrimOpt::Both);
+                    if (*line && *line != '#' && *line != ';') {
+                        char* eq = str::FindChar(line, '=');
+                        if (eq) {
+                            *eq = 0;
+                            str::TrimWSInPlace(line, TrimOpt::Right);
+                            char* val = eq + 1;
+                            str::TrimWSInPlace(val, TrimOpt::Both);
+                            if (str::EqIS(line, "DirDefaultDisplayMode")) {
+                                DisplayMode m = DisplayModeFromString(val, DisplayMode::Automatic);
+                                if (m != DisplayMode::Automatic) {
+                                    return m;
+                                }
+                            }
+                        }
+                    }
+                    if (!next) {
+                        break;
+                    }
+                    line = next + 1;
+                }
+            }
+        }
+        TempStr parent = path::GetDirTemp(dir);
+        if (str::Eq(parent, dir)) {
+            break;
+        }
+        dir = parent;
+    }
+    return DisplayMode::Automatic;
+}
+
 // Document is represented as DocController. Replace current DocController (if any) with ctrl
 // in current tab.
 // meaning of the internal values of LoadArgs:
@@ -1083,6 +1131,13 @@ static void ReplaceDocumentInCurrentTab(LoadArgs* args, DocController* ctrl, Fil
     int showType = SW_NORMAL;
     if (gGlobalPrefs->windowState == WIN_STATE_MAXIMIZED || showAsFullScreen) {
         showType = SW_MAXIMIZE;
+    }
+
+    if (!fs) {
+        DisplayMode dirMode = GetDirDefaultDisplayMode(path);
+        if (dirMode != DisplayMode::Automatic) {
+            displayMode = dirMode;
+        }
     }
 
     if (fs) {


### PR DESCRIPTION
## Summary
- search for `_pdfsettings.txt` when opening a new file
- read `DirDefaultDisplayMode` from that file and use it when no FileState exists

## Testing
- `clang-format -i src/SumatraPDF.cpp`

------
https://chatgpt.com/codex/tasks/task_e_688125a6a41c8330baf60c7b0f044bcf