### PR TITLE
Add mouse-only fullscreen toggle

### DIFF
--- a/docs/releasenotes.txt
+++ b/docs/releasenotes.txt
@@ -10,6 +10,7 @@ Next version:
 * change: to move annotations, must press Ctrl
 * add CmdCommandPaletteOnlyTabs and bind it to Alt + K
 * exit fullscreen / presentation modes via double click with left mouse button
+* entering fullscreen via double click on empty page margin
 * ability to drag out a tab to open it in new window
 * support opening .avif images (including inside .cbz/,cbr files)
 * respect image orientation exif metadata in .jpeg and .png images

--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -633,6 +633,11 @@ static void OnMouseLeftButtonDblClk(MainWindow* win, int x, int y, WPARAM key) {
     }
 
     if (!pageEl) {
+        // Toggle fullscreen when double-clicking on empty margin
+        int pageNo = dm->GetPageNoByPoint(mousePos);
+        if (-1 == pageNo && isLeft && !win->isFullScreen && PM_DISABLED == win->presentation) {
+            ToggleFullScreen(win);
+        }
         return;
     }
     if (pageEl->Is(kindPageElementDest)) {


### PR DESCRIPTION
## Summary
- enable toggling fullscreen by double-clicking on the blank page margin
- mention the new mouse shortcut in `docs/releasenotes.txt`

## Testing
- `clang-format -i src/Canvas.cpp`

------
https://chatgpt.com/codex/tasks/task_e_688132087c888330ac8791b6cbcbdcb8