### PR TITLE
Enable scrollbars outside continuous mode

### DIFF
--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -96,13 +96,49 @@ static void OnVScroll(MainWindow* win, WPARAM wp) {
 
     int currPos = si.nPos;
     auto ctrl = win->ctrl;
+    bool continuous = IsContinuous(ctrl->GetDisplayMode());
     int lineHeight = DpiScale(win->hwndCanvas, 16);
     bool isFitPage = (kZoomFitPage == ctrl->GetZoomVirtual());
-    if (!IsContinuous(ctrl->GetDisplayMode()) && isFitPage) {
+    if (!continuous && isFitPage) {
         lineHeight = 1;
     }
 
     USHORT msg = LOWORD(wp);
+    if (!continuous) {
+        // treat the scrollbar position as page number
+        int pos = ctrl->CurrentPageNo() - 1;
+        switch (msg) {
+            case SB_TOP:
+                pos = 0;
+                break;
+            case SB_BOTTOM:
+                pos = ctrl->PageCount() - 1;
+                break;
+            case SB_LINEUP:
+            case SB_PAGEUP:
+                pos -= 1;
+                break;
+            case SB_LINEDOWN:
+            case SB_PAGEDOWN:
+                pos += 1;
+                break;
+            case SB_THUMBTRACK:
+                pos = si.nTrackPos;
+                break;
+        }
+        si.nMin = 0;
+        si.nMax = ctrl->PageCount() - 1;
+        si.nPage = 1;
+        pos = limitValue(pos, si.nMin, si.nMax);
+        si.nPos = pos;
+        si.fMask = SIF_POS;
+        SetScrollInfo(win->hwndCanvas, SB_VERT, &si, TRUE);
+        if (pos != currPos || msg == SB_THUMBTRACK) {
+            ctrl->GoToPage(pos + 1);
+        }
+        return;
+    }
+
     switch (msg) {
         case SB_TOP:
             si.nPos = si.nMin;
@@ -132,6 +168,8 @@ static void OnVScroll(MainWindow* win, WPARAM wp) {
             si.nPos = si.nTrackPos;
             break;
     }
+
+
 
     // Set the position and then retrieve it.  Due to adjustments
     // by Windows it may not be the same as the value set.
@@ -1541,6 +1579,9 @@ static LRESULT WndProcCanvasFixedPageUI(MainWindow* win, HWND hwnd, UINT msg, WP
 
             if (requiredScrollAxes != -1) {
                 ShowScrollBar(win->hwndCanvas, requiredScrollAxes, !gGlobalPrefs->fixedPageUI.hideScrollbars);
+            } else if (!IsContinuous(win->ctrl->GetDisplayMode()) && !gGlobalPrefs->fixedPageUI.hideScrollbars) {
+                // ensure scrollbar visibility in non-continuous modes
+                ShowScrollBar(win->hwndCanvas, SB_VERT, TRUE);
             }
 
             // allow default processing to continue

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -802,24 +802,33 @@ void ControllerCallbackHandler::UpdateScrollbars(Size canvas) {
     ShowScrollBar(win->hwndCanvas, SB_HORZ, viewPort.dx < canvas.dx);
     SetScrollInfo(win->hwndCanvas, SB_HORZ, &si, TRUE);
 
-    if (viewPort.dy >= canvas.dy) {
-        si.nPos = 0;
-        si.nMin = 0;
-        si.nMax = 99;
-        si.nPage = 100;
-    } else {
-        si.nPos = dm->GetViewPort().y;
-        si.nMin = 0;
-        si.nMax = canvas.dy - 1;
-        si.nPage = viewPort.dy;
+    bool continuous = IsContinuous(dm->GetDisplayMode());
+    if (continuous) {
+        if (viewPort.dy >= canvas.dy) {
+            si.nPos = 0;
+            si.nMin = 0;
+            si.nMax = 99;
+            si.nPage = 100;
+        } else {
+            si.nPos = dm->GetViewPort().y;
+            si.nMin = 0;
+            si.nMax = canvas.dy - 1;
+            si.nPage = viewPort.dy;
 
-        if (kZoomFitPage != dm->GetZoomVirtual()) {
-            // keep the top/bottom 5% of the previous page visible after paging down/up
-            si.nPage = (uint)(si.nPage * 0.95);
-            si.nMax -= viewPort.dy - si.nPage;
+            if (kZoomFitPage != dm->GetZoomVirtual()) {
+                // keep the top/bottom 5% of the previous page visible after paging down/up
+                si.nPage = (uint)(si.nPage * 0.95);
+                si.nMax -= viewPort.dy - si.nPage;
+            }
         }
+        ShowScrollBar(win->hwndCanvas, SB_VERT, viewPort.dy < canvas.dy);
+    } else {
+        si.nPos = dm->CurrentPageNo() - 1;
+        si.nMin = 0;
+        si.nMax = dm->PageCount() - 1;
+        si.nPage = 1;
+        ShowScrollBar(win->hwndCanvas, SB_VERT, TRUE);
     }
-    ShowScrollBar(win->hwndCanvas, SB_VERT, viewPort.dy < canvas.dy);
     SetScrollInfo(win->hwndCanvas, SB_VERT, &si, TRUE);
 }
 


### PR DESCRIPTION
## Summary
- display scrollbars regardless of continuous view mode
- make vertical scrollbar operate on pages when not continuous
- ensure scrollbar shows in non‑continuous modes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688134dfe6088330a4672483c946da5f