### PR TITLE
Improve synchronous display of facing pages

### DIFF
--- a/src/DisplayModel.cpp
+++ b/src/DisplayModel.cpp
@@ -61,6 +61,8 @@
 #include "ProgressUpdateUI.h"
 #include "TextSelection.h"
 #include "TextSearch.h"
+#include "RenderCache.h"
+#include "SumatraPDF.h"
 
 #include "utils/Log.h"
 
@@ -209,6 +211,45 @@ bool DisplayModel::GetDisplayR2L() const {
 
 void DisplayModel::RepaintDisplay() {
     cb->Repaint();
+}
+
+void DisplayModel::OnPageRendered(int pageNo) {
+    if (!waitingForPages) {
+        RepaintDisplay();
+        return;
+    }
+    int idx = waitingPages.Find(pageNo);
+    if (idx >= 0) {
+        waitingReady[idx] = 1;
+    }
+    for (size_t i = 0; i < waitingReady.len; i++) {
+        if (!waitingReady[i]) {
+            return;
+        }
+    }
+    waitingForPages = false;
+    RepaintDisplay();
+}
+
+void DisplayModel::StartPageRenderWait() {
+    waitingPages.Reset();
+    waitingReady.Reset();
+    waitingForPages = false;
+    for (int pageNo = 1; pageNo <= PageCount(); ++pageNo) {
+        PageInfo* pageInfo = GetPageInfo(pageNo);
+        if (pageInfo->visibleRatio > 0.0f) {
+            waitingPages.Append(pageNo);
+            TilePosition tile(gRenderCache.GetTileRes(this, pageNo), 0, 0);
+            bool ready = gRenderCache.Exists(this, pageNo, GetRotation(), GetZoomReal(pageNo), &tile);
+            waitingReady.Append(ready ? 1 : 0);
+            if (!ready) {
+                waitingForPages = true;
+            }
+        }
+    }
+    if (!waitingForPages) {
+        RepaintDisplay();
+    }
 }
 
 bool DisplayModel::InPresentation() const {
@@ -1273,7 +1314,7 @@ void DisplayModel::GoToPage(int pageNo, int scrollY, bool addNavPt, int scrollX)
     RenderVisibleParts();
     cb->UpdateScrollbars(canvasSize);
     cb->PageNoChanged(this, pageNo);
-    RepaintDisplay();
+    StartPageRenderWait();
 }
 
 void DisplayModel::SetDisplayMode(DisplayMode newDisplayMode, bool keepContinuous) {
@@ -1439,7 +1480,7 @@ void DisplayModel::ScrollXTo(int xOff) {
     if (CurrentPageNo() != currPageNo) {
         cb->PageNoChanged(this, CurrentPageNo());
     }
-    RepaintDisplay();
+    StartPageRenderWait();
 }
 
 void DisplayModel::ScrollXBy(int dx) {
@@ -1459,7 +1500,7 @@ void DisplayModel::ScrollYTo(int yOff) {
     if (newPageNo != currPageNo) {
         cb->PageNoChanged(this, newPageNo);
     }
-    RepaintDisplay();
+    StartPageRenderWait();
 }
 
 /* Scroll the doc in y-axis by 'dy'. If 'changePage' is TRUE, automatically
@@ -1517,7 +1558,7 @@ void DisplayModel::ScrollYBy(int dy, bool changePage) {
     if (newPageNo != currPageNo) {
         cb->PageNoChanged(this, newPageNo);
     }
-    RepaintDisplay();
+    StartPageRenderWait();
 }
 
 int DisplayModel::yOffset() {

--- a/src/DisplayModel.h
+++ b/src/DisplayModel.h
@@ -212,6 +212,9 @@ struct DisplayModel : DocController {
     bool GoToPrevPage(int scrollY);
     int GetPageNextToPoint(Point pt) const;
 
+    void OnPageRendered(int pageNo);
+    void StartPageRenderWait();
+
     EngineBase* engine = nullptr;
 
     /* an array of PageInfo, len of array is pageCount */
@@ -261,4 +264,8 @@ struct DisplayModel : DocController {
 
     /* allow resizing a window without triggering a new rendering (needed for window destruction) */
     bool dontRenderFlag = false;
+
+    Vec<int> waitingPages;
+    Vec<int> waitingReady;
+    bool waitingForPages = false;
 };

--- a/src/RenderCache.cpp
+++ b/src/RenderCache.cpp
@@ -697,7 +697,7 @@ DWORD WINAPI RenderCache::RenderCacheThread(LPVOID data) {
                 UpdateBitmapColors(bmp->GetBitmap(), cache->textColor, cache->backgroundColor);
             }
             cache->Add(req, bmp);
-            req.dm->RepaintDisplay();
+            req.dm->OnPageRendered(req.pageNo);
         }
         ResetTempAllocator();
     }


### PR DESCRIPTION
## Summary
- add waiting mechanism for page rendering to avoid mismatched updates
- notify model when a page was rendered and repaint after all pages of a view are ready
- integrate waiting logic into scrolling and page navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688139b09b6c83308a3f6940136c26ac