### PR TITLE
Improve facing page rendering synchronization

### DIFF
--- a/src/DisplayModel.cpp
+++ b/src/DisplayModel.cpp
@@ -1872,7 +1872,13 @@ void DisplayModel::CopyNavHistory(DisplayModel& orig) {
 }
 
 bool DisplayModel::ShouldCacheRendering(int pageNo) const {
-    // recommend caching for all documents
+    DisplayMode mode = GetDisplayMode();
+    // In non-continuous modes render pages synchronously to avoid
+    // pages appearing at different times which may cause flicker.
+    if (!IsContinuous(mode)) {
+        return false;
+    }
+    // default behaviour
     return true;
 }
 


### PR DESCRIPTION
## Summary
- reduce flicker when changing pages in SinglePage, Facing, and BookView modes
- disable asynchronous page rendering in these modes to ensure both pages appear simultaneously

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688139b09b6c83308a3f6940136c26ac