### PR TITLE
Fix page flicker in facing view

### DIFF
--- a/src/DisplayModel.cpp
+++ b/src/DisplayModel.cpp
@@ -61,6 +61,7 @@
 #include "ProgressUpdateUI.h"
 #include "TextSelection.h"
 #include "TextSearch.h"
+#include "SumatraPDF.h"
 
 #include "utils/Log.h"
 
@@ -1140,6 +1141,18 @@ void DisplayModel::RenderVisibleParts() {
     }
 }
 
+void DisplayModel::RenderVisiblePagesSync() {
+    for (int pageNo = 1; pageNo <= PageCount(); ++pageNo) {
+        PageInfo* pageInfo = GetPageInfo(pageNo);
+        if (!pageInfo->shown || pageInfo->visibleRatio <= 0.0f) {
+            continue;
+        }
+        if (!gRenderCache.Exists(this, pageNo, rotation, GetZoomReal(pageNo))) {
+            gRenderCache.RenderSync(this, pageNo);
+        }
+    }
+}
+
 void DisplayModel::SetViewPortSize(Size newViewPortSize) {
     ScrollState ss;
 
@@ -1270,6 +1283,7 @@ void DisplayModel::GoToPage(int pageNo, int scrollY, bool addNavPt, int scrollX)
     viewPort.y = limitValue(viewPort.y, 0, canvasSize.dy - viewPort.dy);
 
     RecalcVisibleParts();
+    RenderVisiblePagesSync();
     RenderVisibleParts();
     cb->UpdateScrollbars(canvasSize);
     cb->PageNoChanged(this, pageNo);

--- a/src/DisplayModel.h
+++ b/src/DisplayModel.h
@@ -205,6 +205,7 @@ struct DisplayModel : DocController {
     Point GetContentStart(int pageNo) const;
     void RecalcVisibleParts() const;
     void RenderVisibleParts();
+    void RenderVisiblePagesSync();
     void AddNavPoint();
     RectF GetContentBox(int pageNo) const;
     void CalcZoomReal(float zoomVirtual);

--- a/src/RenderCache.cpp
+++ b/src/RenderCache.cpp
@@ -413,6 +413,35 @@ void RenderCache::RequestRendering(DisplayModel* dm, int pageNo) {
     }
 }
 
+void RenderCache::RenderSync(DisplayModel* dm, int pageNo) {
+    CrashIf(!dm);
+    if (!dm || dm->dontRenderFlag) {
+        return;
+    }
+    TilePosition tile(0, 0, 0);
+    int rotation = NormalizeRotation(dm->GetRotation());
+    float zoom = dm->GetZoomReal(pageNo);
+
+    if (Exists(dm, pageNo, rotation, zoom, &tile)) {
+        return;
+    }
+
+    PageRenderRequest req{};
+    req.dm = dm;
+    req.pageNo = pageNo;
+    req.rotation = rotation;
+    req.zoom = zoom;
+    req.tile = tile;
+    req.pageRect = GetTileRectUser(dm->GetEngine(), pageNo, rotation, zoom, tile);
+
+    RenderPageArgs args(pageNo, zoom, rotation, &req.pageRect);
+    RenderedBitmap* bmp = dm->GetEngine()->RenderPage(args);
+    if (bmp && !dm->GetEngine()->IsImageCollection()) {
+        UpdateBitmapColors(bmp->GetBitmap(), textColor, backgroundColor);
+    }
+    Add(req, bmp);
+}
+
 /* Render a bitmap for page <pageNo> in <dm>. */
 void RenderCache::RequestRendering(DisplayModel* dm, int pageNo, TilePosition tile, bool clearQueueForPage) {
     logf("RenderCache::RequestRendering(): pageNo %d\n", pageNo);

--- a/src/RenderCache.h
+++ b/src/RenderCache.h
@@ -116,6 +116,8 @@ struct RenderCache {
     ~RenderCache();
 
     void RequestRendering(DisplayModel* dm, int pageNo);
+    // synchronously render a page and store it in the cache
+    void RenderSync(DisplayModel* dm, int pageNo);
     void Render(DisplayModel* dm, int pageNo, int rotation, float zoom, RectF pageRect, RenderingCallback& callback);
     void CancelRendering(DisplayModel* dm);
     bool Exists(DisplayModel* dm, int pageNo, int rotation, float zoom = kInvalidZoom, TilePosition* tile = nullptr);


### PR DESCRIPTION
## Summary
- draw visible pages synchronously so paired pages appear together
- add `RenderSync` helper for blocking page rendering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688139b09b6c83308a3f6940136c26ac