### PR TITLE
Improve page rendering synchronicity

### DIFF
--- a/src/DisplayModel.cpp
+++ b/src/DisplayModel.cpp
@@ -59,6 +59,8 @@
 #include "GlobalPrefs.h"
 #include "PdfSync.h"
 #include "ProgressUpdateUI.h"
+#include "RenderCache.h"
+#include "SumatraPDF.h"
 #include "TextSelection.h"
 #include "TextSearch.h"
 
@@ -208,7 +210,26 @@ bool DisplayModel::GetDisplayR2L() const {
 }
 
 void DisplayModel::RepaintDisplay() {
+    if (!VisiblePagesReady()) {
+        return;
+    }
     cb->Repaint();
+}
+
+bool DisplayModel::VisiblePagesReady() {
+    int rot = GetRotation();
+    for (int pageNo = 1; pageNo <= PageCount(); ++pageNo) {
+        PageInfo* info = GetPageInfo(pageNo);
+        if (!info || info->visibleRatio <= 0.0f || !info->shown) {
+            continue;
+        }
+        float zoom = GetZoomReal(pageNo);
+        TilePosition tile(gRenderCache.GetTileRes(this, pageNo), 0, 0);
+        if (!gRenderCache.Exists(this, pageNo, rot, zoom, &tile)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 bool DisplayModel::InPresentation() const {

--- a/src/DisplayModel.h
+++ b/src/DisplayModel.h
@@ -196,6 +196,9 @@ struct DisplayModel : DocController {
     // called when we decide that the display needs to be redrawn
     void RepaintDisplay();
 
+    // return true if all visible pages are already rendered
+    bool VisiblePagesReady();
+
     bool InPresentation() const;
 
     void BuildPagesInfo();


### PR DESCRIPTION
## Summary
- prevent repainting until all visible pages are rendered
- add `VisiblePagesReady` helper to check rendering state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688139b09b6c83308a3f6940136c26ac