### PR TITLE
Add Shift override for tabbed reuse

### DIFF
--- a/src/SumatraStartup.cpp
+++ b/src/SumatraStartup.cpp
@@ -1168,6 +1168,12 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int) {
     UpdateGlobalPrefs(flags);
     SetCurrentLang(flags.lang ? flags.lang : gGlobalPrefs->uiLanguage);
 
+    // If the Shift key is held when launching a file and tabs are enabled,
+    // open it in a new window instead of a new tab.
+    if (IsShiftPressed() && flags.fileNames.size() > 0 && gGlobalPrefs->useTabs) {
+        flags.inNewWindow = true;
+    }
+
 #if defined(DEBUG)
     void TestBrowser(); // scratch.cpp
     if (flags.testBrowser) {


### PR DESCRIPTION
## Summary
- open a new window when launching a file with Shift held

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885c361da288330948858315592659f