### PR TITLE
Shift key opens PDF in new window

### DIFF
--- a/src/SumatraStartup.cpp
+++ b/src/SumatraStartup.cpp
@@ -1168,6 +1168,10 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int) {
     UpdateGlobalPrefs(flags);
     SetCurrentLang(flags.lang ? flags.lang : gGlobalPrefs->uiLanguage);
 
+    if (!flags.inNewWindow && gGlobalPrefs->useTabs && IsShiftPressed()) {
+        flags.inNewWindow = true;
+    }
+
 #if defined(DEBUG)
     void TestBrowser(); // scratch.cpp
     if (flags.testBrowser) {


### PR DESCRIPTION
## Summary
- open a new window when starting SumatraPDF with Shift pressed
- if UseTabs is enabled and a previous instance exists, Shift now emulates `-new-window`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885c361da288330948858315592659f