### PR TITLE
Add page info to tab titles

### DIFF
--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -880,6 +880,7 @@ void ControllerCallbackHandler::PageNoChanged(DocController* ctrl, int pageNo) {
         if (win->ctrl->HasPageLabels()) {
             UpdateToolbarPageText(win, win->ctrl->PageCount(), true);
         }
+        HwndScheduleRepaint(win->tabsCtrl->hwnd);
     }
     if (pageNo == win->currPageNo) {
         return;

--- a/src/Tabs.cpp
+++ b/src/Tabs.cpp
@@ -494,6 +494,7 @@ void TabsOnChangedDoc(MainWindow* win) {
     CrashIf(win->GetTabIdx(tab) != win->tabsCtrl->GetSelected());
     VerifyWindowTab(win, tab);
     UpdateTabTitle(tab);
+    HwndScheduleRepaint(win->tabsCtrl->hwnd);
 }
 
 // Called when we're closing an entire window (quitting)

--- a/src/wingui/WinGui.cpp
+++ b/src/wingui/WinGui.cpp
@@ -14,6 +14,7 @@
 #include "wingui/WinGui.h"
 
 #include "Theme.h"
+#include "WindowTab.h"
 
 #include "webview2.h"
 
@@ -3457,10 +3458,15 @@ void TabsCtrl::Paint(HDC hdc, RECT& rc) {
     Gdiplus::Rect gr = ToGdipRect(rc);
     gfx.FillRectangle(&br, gr);
 
-    StringFormat sf(StringFormat::GenericDefault());
-    sf.SetFormatFlags(Gdiplus::StringFormatFlagsNoWrap);
-    sf.SetLineAlignment(StringAlignmentCenter);
-    sf.SetTrimming(Gdiplus::StringTrimmingEllipsisCharacter);
+    StringFormat sfFile(StringFormat::GenericDefault());
+    sfFile.SetFormatFlags(Gdiplus::StringFormatFlagsNoWrap);
+    sfFile.SetLineAlignment(StringAlignmentCenter);
+    sfFile.SetTrimming(Gdiplus::StringTrimmingEllipsisCharacter);
+
+    StringFormat sfPage(StringFormat::GenericDefault());
+    sfPage.SetFormatFlags(Gdiplus::StringFormatFlagsNoWrap);
+    sfPage.SetLineAlignment(StringAlignmentCenter);
+    sfPage.SetTrimming(Gdiplus::StringTrimmingNone);
 
     TabInfo* ti;
     int n = TabCount();
@@ -3521,14 +3527,42 @@ void TabsCtrl::Paint(HDC hdc, RECT& rc) {
             gfx.DrawLine(&penX, p1, p2);
         }
 
-        // draw text
+        // draw text: filename and page numbers
         gfx.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
         rTxt = ToGdipRectF(ti->r);
         rTxt.X += 8;
         rTxt.Width -= (8 + r.dx + 8);
+
+        // prepare strings
+        const char* fileTitle = ti->text;
+        WindowTab* wt = (WindowTab*)ti->userData;
+        char pageBuf[32] = "";
+        if (wt && wt->IsDocLoaded()) {
+            int curr = wt->ctrl->CurrentPageNo();
+            int count = wt->ctrl->PageCount();
+            if (count > 0) {
+                snprintf(pageBuf, sizeof(pageBuf), " (%d/%d)", curr, count);
+            }
+        }
+
+        WCHAR* wsPage = ToWstrTemp(pageBuf);
+        Size pageSz{0, 0};
+        if (pageBuf[0]) {
+            pageSz = HwndMeasureText(hwnd, wsPage, GetFont());
+        }
+
+        Gdiplus::RectF rFile = rTxt;
+        rFile.Width = std::max(0.f, rTxt.Width - (float)pageSz.dx);
+        Gdiplus::RectF rPage = rTxt;
+        rPage.X += rFile.Width;
+        rPage.Width = (float)pageSz.dx;
+
         br.SetColor(GdipCol(textColor));
-        WCHAR* ws = ToWstrTemp(ti->text);
-        gfx.DrawString(ws, -1, &f, rTxt, &sf, &br);
+        WCHAR* wsFile = ToWstrTemp(fileTitle);
+        gfx.DrawString(wsFile, -1, &f, rFile, &sfFile, &br);
+        if (pageBuf[0]) {
+            gfx.DrawString(wsPage, -1, &f, rPage, &sfPage, &br);
+        }
     }
 }
 
@@ -3543,10 +3577,15 @@ HBITMAP TabsCtrl::RenderForDragging(int idx) {
     gfx->SetTextRenderingHint(TextRenderingHintClearTypeGridFit);
     gfx->SetPageUnit(UnitPixel);
 
-    StringFormat sf(StringFormat::GenericDefault());
-    sf.SetFormatFlags(Gdiplus::StringFormatFlagsNoWrap);
-    sf.SetLineAlignment(StringAlignmentCenter);
-    sf.SetTrimming(Gdiplus::StringTrimmingEllipsisCharacter);
+    StringFormat sfFile(StringFormat::GenericDefault());
+    sfFile.SetFormatFlags(Gdiplus::StringFormatFlagsNoWrap);
+    sfFile.SetLineAlignment(StringAlignmentCenter);
+    sfFile.SetTrimming(Gdiplus::StringTrimmingEllipsisCharacter);
+
+    StringFormat sfPage(StringFormat::GenericDefault());
+    sfPage.SetFormatFlags(Gdiplus::StringFormatFlagsNoWrap);
+    sfPage.SetLineAlignment(StringAlignmentCenter);
+    sfPage.SetTrimming(Gdiplus::StringTrimmingNone);
 
     COLORREF bgCol = tabSelectedBg;
     COLORREF textCol = tabSelectedText;
@@ -3562,9 +3601,36 @@ HBITMAP TabsCtrl::RenderForDragging(int idx) {
     Gdiplus::RectF rTxt(0, 0, ti->r.dx, ti->r.dy);
     rTxt.X += 8;
     rTxt.Width -= (8 + 8);
+
+    const char* fileTitle = ti->text;
+    WindowTab* wt = (WindowTab*)ti->userData;
+    char pageBuf[32] = "";
+    if (wt && wt->IsDocLoaded()) {
+        int curr = wt->ctrl->CurrentPageNo();
+        int count = wt->ctrl->PageCount();
+        if (count > 0) {
+            snprintf(pageBuf, sizeof(pageBuf), " (%d/%d)", curr, count);
+        }
+    }
+
+    WCHAR* wsPage = ToWstrTemp(pageBuf);
+    Size pageSz{0, 0};
+    if (pageBuf[0]) {
+        pageSz = HwndMeasureText(hwnd, wsPage, GetFont());
+    }
+
+    Gdiplus::RectF rFile = rTxt;
+    rFile.Width = std::max(0.f, rTxt.Width - (float)pageSz.dx);
+    Gdiplus::RectF rPage = rTxt;
+    rPage.X += rFile.Width;
+    rPage.Width = (float)pageSz.dx;
+
     br.SetColor(GdipCol(textCol));
-    WCHAR* ws = ToWstrTemp(ti->text);
-    gfx->DrawString(ws, -1, &f, rTxt, &sf, &br);
+    WCHAR* wsFile = ToWstrTemp(fileTitle);
+    gfx->DrawString(wsFile, -1, &f, rFile, &sfFile, &br);
+    if (pageBuf[0]) {
+        gfx->DrawString(wsPage, -1, &f, rPage, &sfPage, &br);
+    }
 
     HBITMAP ret;
     bitmap.GetHBITMAP(Color(255, 255, 255), &ret);


### PR DESCRIPTION
## Summary
- show current and total page numbers in tab titles
- update tab titles whenever the page changes or a document loads
- ensure page numbers are not truncated by allocating space when painting tabs

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6885f92ed6648330a3fb294cb49be170