### PR TITLE
Add copy page as image command

### DIFF
--- a/src/Commands.h
+++ b/src/Commands.h
@@ -48,6 +48,7 @@ Cmd* enum (e.g. CmdOpen) and a human-readable name (not used yet).
     V(CmdDuplicateInNewWindow, "Open Current Document In New Window")     \
     V(CmdDuplicateInNewTab, "Open Current Document In New Tab")          \
     V(CmdCopyImage, "Copy Image")                                         \
+    V(CmdCopyPageImage, "Copy As Image")                                  \
     V(CmdCopyLinkTarget, "Copy Link Target")                              \
     V(CmdCopyComment, "Copy Comment")                                     \
     V(CmdCopyFilePath, "Copy File Path")                                  \

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -4636,6 +4636,106 @@ void CopyFilePath(WindowTab* tab) {
     // TODO: implement me
 }
 
+static int FirstPageInRow(int pageNo, int columns, bool showCover) {
+    if (showCover && columns > 1) {
+        pageNo++;
+    }
+    int first = pageNo - ((pageNo - 1) % columns);
+    if (showCover && columns > 1 && first > 1) {
+        first--;
+    }
+    return first;
+}
+
+static int LastPageInRow(int pageNo, int columns, bool showCover, int pageCount) {
+    int last = FirstPageInRow(pageNo, columns, showCover) + columns - 1;
+    if (showCover && pageNo < columns) {
+        last--;
+    }
+    if (last > pageCount) {
+        last = pageCount;
+    }
+    return last;
+}
+
+void CopyCurrentPageAsImage(MainWindow* win) {
+    if (!win || !win->IsDocLoaded()) {
+        return;
+    }
+    DisplayModel* dm = win->AsFixed();
+    if (!dm) {
+        return;
+    }
+
+    EngineBase* engine = dm->GetEngine();
+    int pageNo = win->ctrl->CurrentPageNo();
+    DisplayMode mode = win->ctrl->GetDisplayMode();
+    int columns = IsSingle(mode) ? 1 : 2;
+    bool showCover = IsBookView(mode);
+
+    int first = pageNo;
+    int last = pageNo;
+    if (columns > 1) {
+        first = FirstPageInRow(pageNo, columns, showCover);
+        last = LastPageInRow(pageNo, columns, showCover, engine->PageCount());
+    }
+
+    RectF boxes[2] = {};
+    int idx = 0;
+    for (int p = first; p <= last; p++) {
+        boxes[idx++] = engine->Transform(engine->PageMediabox(p), p, 1.0f, dm->GetRotation());
+    }
+
+    float widthPts = boxes[0].dx;
+    float heightPts = boxes[0].dy;
+    if (idx == 2) {
+        widthPts = boxes[0].dx + dm->pageSpacing.dx + boxes[1].dx;
+        heightPts = std::max(boxes[0].dy, boxes[1].dy);
+    }
+
+    Rect monitor = GetFullscreenRect(win->hwndFrame);
+    float zoom = std::min((float)monitor.dx / widthPts, (float)monitor.dy / heightPts);
+
+    RenderPageArgs args(first, zoom, dm->GetRotation(), nullptr, RenderTarget::Export);
+    RenderedBitmap* bmp1 = engine->RenderPage(args);
+    RenderedBitmap* bmp2 = nullptr;
+    if (idx == 2) {
+        args.pageNo = last;
+        bmp2 = engine->RenderPage(args);
+    }
+    if (!bmp1 || !bmp1->IsValid() || (idx == 2 && (!bmp2 || !bmp2->IsValid()))) {
+        delete bmp1;
+        delete bmp2;
+        return;
+    }
+
+    Size size1 = bmp1->GetSize();
+    Size size2 = bmp2 ? bmp2->GetSize() : Size();
+    int spacing = (idx == 2) ? (int)(dm->pageSpacing.dx * zoom) : 0;
+    Size outSize(size1.dx + (idx == 2 ? spacing + size2.dx : 0), std::max(size1.dy, size2.dy));
+
+    HANDLE hMap = nullptr;
+    HBITMAP hbmp = CreateMemoryBitmap(outSize, &hMap);
+    HDC hdc = CreateCompatibleDC(nullptr);
+    DeleteObject(SelectObject(hdc, hbmp));
+    HBRUSH white = (HBRUSH)GetStockObject(WHITE_BRUSH);
+    RECT rc = {0, 0, outSize.dx, outSize.dy};
+    FillRect(hdc, &rc, white);
+
+    bmp1->Blit(hdc, Rect(0, 0, size1.dx, size1.dy));
+    if (idx == 2) {
+        bmp2->Blit(hdc, Rect(size1.dx + spacing, 0, size2.dx, size2.dy));
+    }
+    DeleteDC(hdc);
+    delete bmp1;
+    delete bmp2;
+
+    CopyImageToClipboard(hbmp, false);
+    // ownership transferred to clipboard
+    CloseHandle(hMap);
+    DeleteObject(hbmp);
+}
+
 void ClearHistory(MainWindow* win) {
     if (!win) {
         // TODO: find current active MainWindow ?
@@ -4863,6 +4963,9 @@ static LRESULT FrameOnCommand(MainWindow* win, HWND hwnd, UINT msg, WPARAM wp, L
 
         case CmdCopyFilePath:
             CopyFilePath(tab);
+            break;
+        case CmdCopyPageImage:
+            CopyCurrentPageAsImage(win);
             break;
 
         case CmdCommandPalette:

--- a/src/SumatraPDF.h
+++ b/src/SumatraPDF.h
@@ -125,6 +125,7 @@ void RelayoutWindow(MainWindow* win);
 void DuplicateTabInNewWindow(WindowTab* tab);
 void DuplicateTabInNewTab(WindowTab* tab);
 void CopyFilePath(WindowTab*);
+void CopyCurrentPageAsImage(MainWindow* win);
 
 // note: background tabs are only searched if focusTab is true
 MainWindow* FindMainWindowByFile(const char* file, bool focusTab);

--- a/src/SvgIcons.cpp
+++ b/src/SvgIcons.cpp
@@ -134,6 +134,15 @@ static const char* gIconRotateRight =
   <circle cx="11" cy="19.94" r="0.15"/>
 </svg>)";
 
+// https://github.com/tabler/tabler-icons/blob/master/icons/photo.svg
+static const char* gIconCopyPageImage =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <rect x="3" y="4" width="18" height="16" rx="3" />
+  <circle cx="9" cy="10" r="2" />
+  <path d="M21 15l-5-4l-3 3l-2-2l-4 4" />
+</svg>)";
+
 // must match order in enum class TbIcon
 // clang-format off
 static const char* gAllIcons[] = {
@@ -152,6 +161,7 @@ static const char* gAllIcons[] = {
     gIconSave,
     gIconRotateLeft,
     gIconRotateRight,
+    gIconCopyPageImage,
 };
 // clang-format on
 

--- a/src/SvgIcons.h
+++ b/src/SvgIcons.h
@@ -21,4 +21,5 @@ enum class TbIcon {
     Save,
     RotateLeft,
     RotateRight,
+    CopyPageImage,
 };

--- a/src/Tabs.cpp
+++ b/src/Tabs.cpp
@@ -212,6 +212,14 @@ static MenuDef menuDefContextTab[] = {
         0,
     },
     {
+        _TRN("Copy As Image"),
+        CmdCopyPageImage,
+    },
+    {
+        kMenuSeparator,
+        0,
+    },
+    {
         _TRN("Close"),
         CmdClose,
     },
@@ -320,6 +328,10 @@ static void TabsContextMenu(ContextMenuEvent* ev) {
         }
         case CmdCopyFilePath: {
             CopyFilePath(tabUnderMouse);
+            break;
+        }
+        case CmdCopyPageImage: {
+            CopyCurrentPageAsImage(win);
             break;
         }
         case CmdDuplicateInNewWindow: {

--- a/src/Toolbar.cpp
+++ b/src/Toolbar.cpp
@@ -81,6 +81,8 @@ static ToolbarButtonInfo gToolbarButtons[] = {
     {TbIcon::SearchPrev, CmdFindPrev, _TRN("Find Previous")},
     {TbIcon::SearchNext, CmdFindNext, _TRN("Find Next")},
     {TbIcon::MatchCase, CmdFindMatch, _TRN("Match Case")},
+    {TbIcon::None, 0, nullptr}, // separator
+    {TbIcon::CopyPageImage, CmdCopyPageImage, _TRN("Copy As Image")},
     {TbIcon::None, CmdInfoText, nullptr}, // info text
 };
 

--- a/translations/translations-good.txt
+++ b/translations/translations-good.txt
@@ -17629,4 +17629,4 @@ tl:ipini-print ang dokumento
 tr:belge yazdırılıyor
 tw:正在列印文件
 uk:друк документа
-vn:đang in tập tin
+vn:đang in tập tin::Copy As Image

--- a/translations/translations.txt
+++ b/translations/translations.txt
@@ -21734,3 +21734,4 @@ uk:друк документа
 uz:hujjatni chop etish
 vn:đang in tập tin
 :Open In New Tab
+::Copy As Image


### PR DESCRIPTION
## Summary
- add `CmdCopyPageImage` command
- extend tab context menu with 'Copy As Image'
- add toolbar button for copying current page as image
- implement image copy logic rendering page(s) at monitor resolution
- provide toolbar icon for screenshot

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688605fe49f083308d1c15a89fa742c1