### PR TITLE
Fix page label navigation and display

### DIFF
--- a/src/DisplayModel.cpp
+++ b/src/DisplayModel.cpp
@@ -136,6 +136,31 @@ int DisplayModel::GetPageByLabel(const char* label) const {
     return engine->GetPageByLabel(label);
 }
 
+int DisplayModel::LogicalPageCount() const {
+    if (!HasPageLabels()) {
+        return PageCount();
+    }
+    if (logicalPageCountCache > 0) {
+        return logicalPageCountCache;
+    }
+    int count = PageCount();
+    int maxVal = 0;
+    for (int i = 1; i <= count; i++) {
+        AutoFreeStr label(GetPageLabel(i));
+        int val = 0;
+        if (str::Parse(label, "%d%$", &val)) {
+            if (val > maxVal) {
+                maxVal = val;
+            }
+        }
+    }
+    if (maxVal <= 0) {
+        maxVal = count;
+    }
+    logicalPageCountCache = maxVal;
+    return maxVal;
+}
+
 // common shortcuts
 bool DisplayModel::ValidPageNo(int pageNo) const {
     if (!engine) {

--- a/src/DisplayModel.h
+++ b/src/DisplayModel.h
@@ -106,6 +106,7 @@ struct DisplayModel : DocController {
     bool HasPageLabels() const override;
     char* GetPageLabel(int pageNo) const override;
     int GetPageByLabel(const char* label) const override;
+    int LogicalPageCount() const override;
 
     // common shortcuts
     bool ValidPageNo(int pageNo) const override;
@@ -261,4 +262,6 @@ struct DisplayModel : DocController {
 
     /* allow resizing a window without triggering a new rendering (needed for window destruction) */
     bool dontRenderFlag = false;
+
+    mutable int logicalPageCountCache = 0;
 };

--- a/src/DocController.h
+++ b/src/DocController.h
@@ -118,6 +118,9 @@ struct DocController {
     virtual int GetPageByLabel(const char* label) const {
         return atoi(label);
     }
+    virtual int LogicalPageCount() const {
+        return PageCount();
+    }
 
     // common shortcuts
     virtual bool ValidPageNo(int pageNo) const {

--- a/src/EngineDjVu.cpp
+++ b/src/EngineDjVu.cpp
@@ -1185,7 +1185,7 @@ char* EngineDjVu::GetPageLabel(int pageNo) const {
 }
 
 int EngineDjVu::GetPageByLabel(const char* label) const {
-    for (size_t i = 0; i < fileInfos.size(); i++) {
+    for (int i = (int)fileInfos.size() - 1; i >= 0; i--) {
         ddjvu_fileinfo_t& info = fileInfos.at(i);
         if (str::EqI(info.title, label) && !str::Eq(info.title, info.id)) {
             return info.pageno + 1;

--- a/src/EngineImages.cpp
+++ b/src/EngineImages.cpp
@@ -879,7 +879,7 @@ char* EngineImageDir::GetPageLabel(int pageNo) const {
 
 int EngineImageDir::GetPageByLabel(const char* label) const {
     size_t nLabel = str::Len(label);
-    for (int i = 0; i < pageFileNames.Size(); i++) {
+    for (int i = pageFileNames.Size() - 1; i >= 0; i--) {
         char* pagePath = pageFileNames[i];
         const char* fileName = path::GetBaseNameTemp(pagePath);
         char* ext = path::GetExtTemp(fileName);

--- a/src/EngineMupdf.cpp
+++ b/src/EngineMupdf.cpp
@@ -3380,7 +3380,12 @@ int EngineMupdf::GetPageByLabel(const char* label) const {
     }
     int pageNo = 0;
     if (pageLabels) {
-        pageNo = pageLabels->Find(label) + 1;
+        for (int i = pageLabels->Size() - 1; i >= 0; i--) {
+            if (str::Eq(label, pageLabels->at(i))) {
+                pageNo = i + 1;
+                break;
+            }
+        }
     }
 
     if (!pageNo) {

--- a/src/Toolbar.cpp
+++ b/src/Toolbar.cpp
@@ -644,8 +644,9 @@ void UpdateToolbarPageText(MainWindow* win, int pageCount, bool updateOnly) {
     } else if (!win->ctrl || !win->ctrl->HasPageLabels()) {
         buf = str::Format(" / %d", pageCount);
     } else {
-        buf = str::Format(" (%d / %d)", win->ctrl->CurrentPageNo(), pageCount);
-        AutoFreeStr buf2(str::Format(" (%d / %d)", pageCount, pageCount));
+        int logicalCount = win->ctrl->LogicalPageCount();
+        buf = str::Format(" / %d (%d / %d)", logicalCount, win->ctrl->CurrentPageNo(), pageCount);
+        AutoFreeStr buf2(str::Format(" / %d (%d / %d)", logicalCount, pageCount, pageCount));
         size2 = TextSizeInHwnd(win->hwndPageTotal, buf2);
     }
 

--- a/src/wingui/WinGui.cpp
+++ b/src/wingui/WinGui.cpp
@@ -3546,6 +3546,13 @@ void TabsCtrl::Paint(HDC hdc, RECT& rc) {
         if (wt && wt->IsDocLoaded()) {
             int curr = wt->ctrl->CurrentPageNo();
             int count = wt->ctrl->PageCount();
+            if (wt->ctrl->HasPageLabels()) {
+                AutoFreeStr label(wt->ctrl->GetPageLabel(curr));
+                int logicalCurr = curr;
+                str::Parse(label, "%d%$", &logicalCurr);
+                curr = logicalCurr;
+                count = wt->ctrl->LogicalPageCount();
+            }
             if (count > 0) {
                 snprintf(pageBuf, sizeof(pageBuf), " (%d/%d)", curr, count);
             }
@@ -3615,6 +3622,13 @@ HBITMAP TabsCtrl::RenderForDragging(int idx) {
     if (wt && wt->IsDocLoaded()) {
         int curr = wt->ctrl->CurrentPageNo();
         int count = wt->ctrl->PageCount();
+        if (wt->ctrl->HasPageLabels()) {
+            AutoFreeStr label(wt->ctrl->GetPageLabel(curr));
+            int logicalCurr = curr;
+            str::Parse(label, "%d%$", &logicalCurr);
+            curr = logicalCurr;
+            count = wt->ctrl->LogicalPageCount();
+        }
         if (count > 0) {
             snprintf(pageBuf, sizeof(pageBuf), " (%d/%d)   ", curr, count);
         }


### PR DESCRIPTION
## Summary
- ensure GetPageByLabel prefers later matching pages
- report logical page count in DocController and DisplayModel
- show logical total on the toolbar when page labels exist
- display logical page numbers on tabs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6886154e2d54833089dabc3e15baba2e